### PR TITLE
fixes to build effil on windows

### DIFF
--- a/src/cpp/lua-module.cpp
+++ b/src/cpp/lua-module.cpp
@@ -49,8 +49,12 @@ std::string userdataType(const sol::object& something) {
 
 } // namespace
 
-extern "C" int luaopen_libeffil(lua_State* L) {
-    sol::state_view lua(L);
+extern "C"
+#ifdef _WIN32
+ __declspec(dllexport)
+#endif
+int luaopen_libeffil(lua_State* L) {
+	sol::state_view lua(L);
     Thread::getUserType(lua);
     SharedTable::getUserType(lua);
     Channel::getUserType(lua);

--- a/src/cpp/shared-table.cpp
+++ b/src/cpp/shared-table.cpp
@@ -246,7 +246,7 @@ SharedTable::PairsIterator SharedTable::luaPairs(sol::this_state state) {
         sol::make_object(state, *this));
 }
 
-std::pair<sol::object, sol::object> ipairsNext(sol::this_state lua, SharedTable table, sol::optional<LUA_INDEX_TYPE> key) {
+std::pair<sol::object, sol::object> ipairsNext(sol::this_state lua, SharedTable table, const sol::optional<LUA_INDEX_TYPE>& key) {
     size_t index = key ? key.value() + 1 : 1;
     auto objKey = createStoredObject(static_cast<LUA_INDEX_TYPE>(index));
     sol::object value = table.get(objKey, lua);

--- a/src/cpp/stored-object.h
+++ b/src/cpp/stored-object.h
@@ -26,7 +26,6 @@ public:
 
 private:
     BaseHolder(const BaseHolder&) = delete;
-    BaseHolder(BaseHolder&) = delete;
 };
 
 typedef std::shared_ptr<BaseHolder> StoredObject;

--- a/tests/lua/thread.lua
+++ b/tests/lua/thread.lua
@@ -220,9 +220,9 @@ end
 
 test.thread.timed_cancel = function ()
     local thread = effil.thread(function()
-        require("effil").sleep(2)
+        require("effil").sleep(4)
     end)()
-    test.is_false(thread:cancel(1))
+    test.is_false(thread:cancel(100, "ms"))
     thread:wait()
 end
 
@@ -317,9 +317,9 @@ test.this_thread.cancel_with_yield = function ()
 end
 
 test.this_thread.pause_with_yield = function ()
-    local share = effil.table()
+    local share = effil.table({stop = false})
     local spec = effil.thread(function (share)
-        for i=1,10000 do
+        while not share.stop do
             require("effil").yield()
         end
         share.done = true
@@ -331,6 +331,9 @@ test.this_thread.pause_with_yield = function ()
     thr:pause()
     test.is_nil(share.done)
     test.equal(thr:status(), "paused")
+    share.stop = true
+    effil.sleep(100, "ms")
+    test.is_nil(share.done)
     thr:resume()
 
     test.is_true(thr:get())


### PR DESCRIPTION
Один тест все еще фейлиться - тест на метатаблицы с использованием глобального ipairs метода. Причем не работает не только метаметод `__ipairs` SharedTable'а, но и `__ipairs` в "чистом" Lua. Мб баг в сборке самого Lua, мб что-то еще.