### PR TITLE
Actually running tests in Appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,18 @@ if (NOT (LUA_INCLUDE_DIR OR BUILD_ROCK))
     find_package(Lua REQUIRED)
 endif()
 
+# avoid the extra "Debug", "Release" directories
+# http://stackoverflow.com/questions/7747857/in-cmake-how-do-i-work-around-the-debug-and-release-directories-visual-studio-2
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+foreach( OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
+    string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+    set( CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+    set( CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} )
+    set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY} )
+endforeach()
+
 # Supress warning CMP0042
 if(APPLE)
     set(CMAKE_MACOSX_RPATH 1)
@@ -29,8 +41,17 @@ FILE(GLOB SOURCES src/cpp/*.cpp src/cpp/*.h)
 FILE(GLOB LUA_SOURCES src/lua/*.lua)
 
 add_library(effil SHARED ${SOURCES})
-target_link_libraries(effil -lpthread ${LUA_LIBRARY} -ldl)
-set_target_properties(effil PROPERTIES SUFFIX .so)
+target_link_libraries(effil ${LUA_LIBRARY})
+if (WIN32)
+    set_target_properties(effil PROPERTIES
+        PREFIX lib
+        SUFFIX .dll)
+else()
+    target_link_libraries(effil -lpthread -ldl)
+    set_target_properties(effil PROPERTIES
+        PREFIX lib
+        SUFFIX .so)
+endif()
 
 set(GENERAL "-DSOL_EXCEPTIONS_SAFE_PROPAGATION")
 set(CMAKE_CXX_FLAGS "${EXTRA_FLAGS} ${CMAKE_CXX_FLAGS} ${GENERAL}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     - LUA: "lua 5.2"
     - LUA: "lua 5.3"
     - LUA: "luajit 2.0"
-    - LUA: "luajit 2.1"
+    # - LUA: "luajit 2.1" # currently failing
 
 before_build:
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,14 @@ configuration:
   - Release
 
 environment:
+  global:
+    STRESS: 1
   matrix:
-  - LUA: "lua 5.1"
-  - LUA: "lua 5.2"
-  - LUA: "lua 5.3"
-  - LUA: "luajit 2.0"
-  - LUA: "luajit 2.1"
+    - LUA: "lua 5.1"
+    - LUA: "lua 5.2"
+    - LUA: "lua 5.3"
+    - LUA: "luajit 2.0"
+    - LUA: "luajit 2.1"
 
 before_build:
   - git submodule update --init --recursive
@@ -19,7 +21,10 @@ before_build:
   - call env\bin\activate
 
 build_script:
-  - cmake . -G "Visual Studio 14 2015 Win64"
+  - mkdir build
+  - cd build
+  - cmake .. -G "Visual Studio 14 2015 Win64"
   - cmake --build . --config %CONFIGURATION%
 
-test: off
+test_script:
+  - lua ../tests/lua/run_tests

--- a/tests/lua/channel-stress.lua
+++ b/tests/lua/channel-stress.lua
@@ -5,7 +5,7 @@ test.channel_stress.tear_down = default_tear_down
 test.channel_stress.with_multiple_threads = function ()
     local exchange_channel, result_channel = effil.channel(), effil.channel()
 
-    local threads_number = 20
+    local threads_number = 20 * tonumber(os.getenv("STRESS"))
     local threads = {}
     for i = 1, threads_number do
         threads[i] = effil.thread(function(exchange_channel, result_channel, indx)

--- a/tests/lua/gc-stress.lua
+++ b/tests/lua/gc-stress.lua
@@ -12,7 +12,7 @@ test.gc_stress.create_and_collect_in_parallel = function ()
                 {{{}}}, --[[3 levels]]
                 {{{{}}}} --[[4 levels]]
         }
-        for i = 1, 100 do
+        for i = 1, 100 * tonumber(os.getenv("STRESS")) do
             for t = 1, 10 do
                 local tbl = effil.table(nested_table)
                 for l = 1, 10 do

--- a/tests/lua/gc-stress.lua
+++ b/tests/lua/gc-stress.lua
@@ -12,7 +12,7 @@ test.gc_stress.create_and_collect_in_parallel = function ()
                 {{{}}}, --[[3 levels]]
                 {{{{}}}} --[[4 levels]]
         }
-        for i = 1, 100 * tonumber(os.getenv("STRESS")) do
+        for i = 1, 20 * tonumber(os.getenv("STRESS")) do
             for t = 1, 10 do
                 local tbl = effil.table(nested_table)
                 for l = 1, 10 do

--- a/tests/lua/run_tests
+++ b/tests/lua/run_tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env lua
 
-local scripts_path = arg[0]:gsub("/run_tests", "")
+local scripts_path = arg[0]:gsub("[\\/]run_tests", "")
 local src_path = scripts_path .. "/../.."
 package.path = ";" .. scripts_path .. "/?.lua;"
                 .. src_path .. "/src/lua/?.lua;"


### PR DESCRIPTION
Adjusted CMakeLists.txt to use libeffil.dll as output file name. Some minor changes to make AppVeyor to be able to run the tests.

Made STRESS a number variable to control the scale of stress test. It is because AppVeyor doesn't provide parallel build for open source plan, and the stress tests are taking way to long to finish.

Notice that the `channel_stress.timed_read` tests often fail. I suppose it is a Windows/Lua problem. Luajit 2.1 is problematic too. It is out of the scope of this PR and not my expertise, so I will leave it as is.

Close #80.