### PR TITLE
Upvalues: replace upvalue only if it's equal to _G

### DIFF
--- a/src/cpp/function.h
+++ b/src/cpp/function.h
@@ -7,8 +7,6 @@
 
 namespace effil {
 
-sol::object luaAllowTableUpvalues(sol::this_state state, const sol::stack_object&);
-
 class FunctionData : public GCData {
 public:
     std::string function;

--- a/src/cpp/lua-module.cpp
+++ b/src/cpp/lua-module.cpp
@@ -107,7 +107,6 @@ int luaopen_effil(lua_State* L) {
             "pairs",        SharedTable::globalLuaPairs,
             "ipairs",       SharedTable::globalLuaIPairs,
             "size",         luaSize,
-            "allow_table_upvalues",    luaAllowTableUpvalues,
             "hardware_threads",        std::thread::hardware_concurrency,
             sol::meta_function::index, luaIndex
     );

--- a/tests/lua/type_mismatch.lua
+++ b/tests/lua/type_mismatch.lua
@@ -122,11 +122,6 @@ local function generate_tests()
             --  effil.gc.step
             test.type_mismatch.input_types_mismatch_p(1, "number", "gc.step", type_instance)
         end
-
-        if typename ~= "boolean" then
-            -- effil.allow_table_upvalue
-            test.type_mismatch.input_types_mismatch_p(1, "boolean", "allow_table_upvalues", type_instance)
-        end
     end
 
     -- Below presented tests which support everything except coroutines
@@ -155,6 +150,5 @@ end
 generate_tests()
 
 test.type_mismatch.gc_checks_after_tests = function()
-    effil.allow_table_upvalues(true)
     default_tear_down()
 end


### PR DESCRIPTION
 * Do not see on upvalues names, only check whether upvalue equals to _G
 * In lua5.1/JIT2.0 we are not able to set userdata as function env using `lua_setfenv`, so for right now we do not support custom ENV for these Lua versions