### PR TITLE
Dont customize package.cpath in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Requires C++14 compiler compliance. Tested with GCC 4.9+, clang 3.8 and Visual S
 1. `git clone --recursive git@github.com:effil/effil.git effil`
 2. `cd effil && mkdir build && cd build`
 3. `cmake .. && make install`
-4. Copy effil.lua and libeffil.so/libeffil.dylib to your project.
+4. Copy effil.so to your project.
 
 ### From lua rocks
 `luarocks install effil`

--- a/tests/lua/run_tests
+++ b/tests/lua/run_tests
@@ -7,7 +7,6 @@ local src_path = scripts_path .. "/../.."
 package.path = ";" .. scripts_path .. "/?.lua;"
                 .. src_path .. "/src/lua/?.lua;"
                 .. src_path .. "/libs/u-test/?.lua"
-package.cpath = "./?.so;" .. package.cpath
 
 require "type"
 require "gc"


### PR DESCRIPTION
closes #121

Let's get rid of `package.cpath` modifications to be sure that we can work with standard env