### PR TITLE
Proposal: Add mutex with scoped locks

### DIFF
--- a/src/cpp/lua-helpers.h
+++ b/src/cpp/lua-helpers.h
@@ -9,6 +9,7 @@ namespace effil {
 class SharedTable;
 class Channel;
 class Thread;
+class SpinMutex;
 
 std::string dumpFunction(const sol::function& f);
 sol::function loadString(const sol::state_view& lua, const std::string& str,
@@ -24,6 +25,8 @@ std::string luaTypename(const SolObject& obj) {
             return "effil.channel";
         else if (obj.template is<Thread>())
             return "effil.thread";
+        else if (obj.template is<SpinMutex>())
+            return "effil.mutex";
         else
             return "userdata";
     }

--- a/src/cpp/lua-module.cpp
+++ b/src/cpp/lua-module.cpp
@@ -83,6 +83,7 @@ int luaopen_effil(lua_State* L) {
     SharedTable::exportAPI(lua);
     Channel::exportAPI(lua);
     ThreadRunner::exportAPI(lua);
+    SpinMutex::exportAPI(lua);
 
     const sol::table  gcApi     = GC::exportAPI(lua);
     const sol::object gLuaTable = sol::make_object(lua, globalTable);
@@ -95,16 +96,12 @@ int luaopen_effil(lua_State* L) {
         else if (key == "gc")
             return gcApi;
         else if (key == "version")
-            return sol::make_object(obj.lua_state(), "0.1.0");
+            return sol::make_object(obj.lua_state(), "1.0.0");
         return sol::nil;
     };
 
     sol::usertype<EffilApiMarker> type("new", sol::no_constructor,
             "mutex",        createMutex,
-            "shared_lock",  mutex::sharedLock,
-            "unique_lock",  mutex::uniqueLock,
-            "try_shared_lock",  mutex::trySharedLock,
-            "try_unique_lock",  mutex::tryUniqueLock,
             "thread",       createThreadRunner,
             "thread_id",    threadId,
             "sleep",        sleep,

--- a/src/cpp/lua-module.cpp
+++ b/src/cpp/lua-module.cpp
@@ -24,6 +24,10 @@ sol::object createChannel(const sol::stack_object& capacity, sol::this_state lua
     return sol::make_object(lua, GC::instance().create<Channel>(capacity));
 }
 
+sol::object createMutex(sol::this_state lua) {
+    return sol::make_object(lua, std::make_shared<SpinMutex>());
+}
+
 SharedTable globalTable = GC::instance().create<SharedTable>();
 
 std::string getLuaTypename(const sol::stack_object& obj) {
@@ -96,6 +100,11 @@ int luaopen_effil(lua_State* L) {
     };
 
     sol::usertype<EffilApiMarker> type("new", sol::no_constructor,
+            "mutex",        createMutex,
+            "shared_lock",  mutex::sharedLock,
+            "unique_lock",  mutex::uniqueLock,
+            "try_shared_lock",  mutex::trySharedLock,
+            "try_unique_lock",  mutex::tryUniqueLock,
             "thread",       createThreadRunner,
             "thread_id",    threadId,
             "sleep",        sleep,

--- a/src/cpp/spin-mutex.cpp
+++ b/src/cpp/spin-mutex.cpp
@@ -1,0 +1,145 @@
+#include "spin-mutex.h"
+#include "lua-helpers.h"
+
+namespace effil {
+
+void SpinMutex::lock() noexcept {
+    while (lock_.exchange(true, std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    while (counter_ != 0) {
+        std::this_thread::yield();
+    }
+}
+
+bool SpinMutex::try_lock() noexcept {
+    if (lock_.exchange(true, std::memory_order_acquire)) {
+        return false;
+    }
+    if (counter_ != 0) {
+        lock_.exchange(false, std::memory_order_release);
+        return false;
+    }
+    return true;
+}
+
+void SpinMutex::unlock() noexcept {
+    lock_.exchange(false, std::memory_order_release);
+}
+
+void SpinMutex::lock_shared() noexcept {
+    while (true) {
+        while (lock_) {
+            std::this_thread::yield();
+        }
+
+        counter_.fetch_add(1, std::memory_order_acquire);
+
+        if (lock_)
+            counter_.fetch_sub(1, std::memory_order_release);
+        else
+            return;
+    }
+}
+
+bool SpinMutex::try_lock_shared() noexcept {
+    if (lock_) {
+        return false;
+    }
+
+    counter_.fetch_add(1, std::memory_order_acquire);
+
+    if (lock_) {
+        counter_.fetch_sub(1, std::memory_order_release);
+        return false;
+    }
+    return true;
+}
+
+void SpinMutex::unlock_shared() noexcept {
+    counter_.fetch_sub(1, std::memory_order_release);
+}
+
+namespace mutex {
+
+void uniqueLock(const sol::stack_object& objMutex,
+                const sol::stack_object& objFunc) {
+    REQUIRE(objMutex.is<SpinMutex>())
+            << "bad argument #1 to 'effil.unique_lock' (mutex expected, got "
+            << luaTypename(objMutex) << ")";
+    REQUIRE(objFunc.get_type() == sol::type::function)
+            << "bad argument #2 to 'effil.unique_lock' (function expected, got "
+            << luaTypename(objFunc) << ")";
+    auto& mutex = objMutex.as<SpinMutex>();
+    const auto& func = objFunc.as<sol::protected_function>();
+
+    mutex.lock();
+    ScopeGuard g([&mutex](){ mutex.unlock(); });
+    const auto ret = func();
+    if (!ret.valid())
+        throw ret.get<sol::error>();
+}
+
+void sharedLock(const sol::stack_object& objMutex,
+                const sol::stack_object& objFunc) {
+    REQUIRE(objMutex.is<SpinMutex>())
+            << "bad argument #1 to 'effil.shared_lock' (mutex expected, got "
+            << luaTypename(objMutex) << ")";
+    REQUIRE(objFunc.get_type() == sol::type::function)
+            << "bad argument #2 to 'effil.shared_lock' (function expected, got "
+            << luaTypename(objFunc) << ")";
+    auto& mutex = objMutex.as<SpinMutex>();
+    const auto& func = objFunc.as<sol::function>();
+
+    mutex.lock_shared();
+    ScopeGuard g([&mutex](){ mutex.unlock_shared(); });
+    const auto ret = func();
+    if (!ret.valid())
+        throw ret.get<sol::error>();
+}
+
+bool tryUniqueLock(const sol::stack_object& objMutex,
+                   const sol::stack_object& objFunc) {
+    REQUIRE(objMutex.is<SpinMutex>())
+            << "bad argument #1 to 'effil.try_unique_lock' (mutex expected, got "
+            << luaTypename(objMutex) << ")";
+    REQUIRE(objFunc.get_type() == sol::type::function)
+            << "bad argument #2 to 'effil.try_unique_lock' (function expected, got "
+            << luaTypename(objFunc) << ")";
+    auto& mutex = objMutex.as<SpinMutex>();
+    const auto& func = objFunc.as<sol::function>();
+
+    if (!mutex.try_lock())
+        return false;
+
+    ScopeGuard g([&mutex](){ mutex.unlock(); });
+    const auto ret = func();
+    if (!ret.valid())
+        throw ret.get<sol::error>();
+    return true;
+}
+
+bool trySharedLock(const sol::stack_object& objMutex,
+                   const sol::stack_object& objFunc) {
+    REQUIRE(objMutex.is<SpinMutex>())
+            << "bad argument #1 to 'effil.try_shared_lock' (mutex expected, got "
+            << luaTypename(objMutex) << ")";
+    REQUIRE(objFunc.get_type() == sol::type::function)
+            << "bad argument #2 to 'effil.try_shared_lock' (function expected, got "
+            << luaTypename(objFunc) << ")";
+    auto& mutex = objMutex.as<SpinMutex>();
+    const auto& func = objFunc.as<sol::function>();
+
+    if (!mutex.try_lock_shared())
+        return false;
+
+    ScopeGuard g([&mutex](){ mutex.unlock_shared(); });
+    const auto ret = func();
+    if (!ret.valid())
+        throw ret.get<sol::error>();
+    return true;
+}
+
+} // mutex
+
+} // effil

--- a/src/cpp/spin-mutex.h
+++ b/src/cpp/spin-mutex.h
@@ -17,21 +17,17 @@ public:
     bool try_lock_shared() noexcept;
     void unlock_shared() noexcept;
 
+    /// Lua API methods
+    void luaUniqueLock(const sol::stack_object& clbk);
+    void luaSharedLock(const sol::stack_object& clbk);
+    bool luaTryUniqueLock(const sol::stack_object& clbk);
+    bool luaTrySharedLock(const sol::stack_object& objMutex);
+
+    static void exportAPI(sol::state_view& lua);
+
 private:
     std::atomic_int counter_ {0};
     std::atomic_bool lock_ {false};
 };
-
-namespace mutex {
-
-void uniqueLock(const sol::stack_object& objMutex, const sol::stack_object& objFunc);
-void sharedLock(const sol::stack_object& objMutex, const sol::stack_object& objFunc);
-
-bool tryUniqueLock(const sol::stack_object& objMutex,
-                   const sol::stack_object& objFunc);
-bool trySharedLock(const sol::stack_object& objMutex,
-                   const sol::stack_object& objFunc);
-
-} // mutex
 
 } // effil

--- a/src/cpp/stored-object.cpp
+++ b/src/cpp/stored-object.cpp
@@ -168,6 +168,8 @@ void dumpTable(SharedTable& target, const sol::table& luaTable, SolTableToShared
     }
 }
 
+typedef std::shared_ptr<SpinMutex> MutexPtr;
+
 template <typename SolObject>
 StoredObject fromSolObject(const SolObject& luaObject, SolTableToShared& visited) {
     switch (luaObject.get_type()) {
@@ -205,6 +207,8 @@ StoredObject fromSolObject(const SolObject& luaObject, SolTableToShared& visited
                 return std::make_unique<ApiReferenceHolder>();
             else if (luaObject.template is<ThreadRunner>())
                 return std::make_unique<GCObjectHolder<ThreadRunner>>(luaObject);
+            else if (luaObject.template is<MutexPtr>())
+                return std::make_unique<PrimitiveHolder<MutexPtr>>(luaObject);
             else
                 throw Exception() << "Unable to store userdata object";
         case sol::type::function: {

--- a/tests/lua/mutex.lua
+++ b/tests/lua/mutex.lua
@@ -1,0 +1,103 @@
+require "bootstrap-tests"
+
+local effil = effil
+
+test.mutex.tear_down = default_tear_down
+
+test.mutex.locking = function()
+    local m = effil.mutex()
+    local tbl = effil.table { val = 0, start = false}
+
+    local worker = function(inc)
+        while not tbl.start do end
+
+        for i = 1, 1000 do
+            effil.unique_lock(m, function()
+                if inc then
+                    tbl.val = tbl.val + 1
+                else
+                    tbl.val = tbl.val - 1
+                end
+            end)
+        end
+    end
+
+    local threadInc = effil.thread(worker)(true)
+    local threadDec = effil.thread(worker)(false)
+    tbl.start = true
+    test.equal(threadInc:wait(), "completed")
+    test.equal(threadDec:wait(), "completed")
+
+    test.equal(tbl.val, 0)
+end
+
+local function try_lock(m, lock_type)
+    return effil['try_' .. lock_type .. '_lock'](m, function() end)
+end
+
+local function lock(m, lock_type)
+    local ctl = {}
+    local state = effil.table { do_lock = true, on_lock = false }
+
+    function ctl.unlock()
+        state.do_lock = false
+        test.equal(ctl.thread:wait(), "completed")
+    end
+
+    ctl.thread = effil.thread(function()
+        effil[lock_type .. '_lock'](m, function()
+            state.on_lock = true
+            while state.do_lock do end
+        end)
+        state.on_lock = false
+    end)()
+
+    test.is_true(wait(2, function() return state.on_lock end))
+    return ctl
+end
+
+test.mutex.unique_lock = function()
+    local m = effil.mutex()
+
+    local l = lock(m, 'unique')
+    test.is_false(try_lock(m, 'unique'))
+    test.is_false(try_lock(m, 'shared'))
+    l:unlock()
+end
+
+test.mutex.try_unique_lock = function()
+    local m = effil.mutex()
+
+    local l = lock(m, 'try_unique')
+    test.is_false(try_lock(m, 'unique'))
+    test.is_false(try_lock(m, 'shared'))
+    l:unlock()
+end
+
+test.mutex.shared_lock = function()
+    local m = effil.mutex()
+
+    local l = lock(m, 'shared')
+    test.is_true(try_lock(m,  'shared'))
+    test.is_false(try_lock(m, 'unique'))
+    l:unlock()
+end
+
+test.mutex.try_shared_lock = function()
+    local m = effil.mutex()
+
+    local l = lock(m, 'try_shared')
+    test.is_true(try_lock(m,  'shared'))
+    test.is_false(try_lock(m, 'unique'))
+    l:unlock()
+end
+
+test.mutex.error_under_lock = function()
+    local m = effil.mutex()
+
+    local ret = pcall(effil.unique_lock, m, function()
+        error('wow')
+    end)
+    test.is_false(ret)
+    test.is_true(effil.try_unique_lock(m, function()end))
+end

--- a/tests/lua/mutex.lua
+++ b/tests/lua/mutex.lua
@@ -12,7 +12,7 @@ test.mutex.locking = function()
         while not tbl.start do end
 
         for i = 1, 1000 do
-            effil.unique_lock(m, function()
+            m:unique_lock(function()
                 if inc then
                     tbl.val = tbl.val + 1
                 else
@@ -32,7 +32,7 @@ test.mutex.locking = function()
 end
 
 local function try_lock(m, lock_type)
-    return effil['try_' .. lock_type .. '_lock'](m, function() end)
+    return m['try_' .. lock_type .. '_lock'](m, function() end)
 end
 
 local function lock(m, lock_type)
@@ -45,7 +45,7 @@ local function lock(m, lock_type)
     end
 
     ctl.thread = effil.thread(function()
-        effil[lock_type .. '_lock'](m, function()
+        m[lock_type .. '_lock'](m, function()
             state.on_lock = true
             while state.do_lock do end
         end)
@@ -95,9 +95,9 @@ end
 test.mutex.error_under_lock = function()
     local m = effil.mutex()
 
-    local ret = pcall(effil.unique_lock, m, function()
+    local ret = pcall(m.unique_lock, m, function()
         error('wow')
     end)
     test.is_false(ret)
-    test.is_true(effil.try_unique_lock(m, function()end))
+    test.is_true(m:try_unique_lock(function()end))
 end

--- a/tests/lua/run_tests
+++ b/tests/lua/run_tests
@@ -22,6 +22,7 @@ require "type_mismatch"
 require "upvalues"
 require "dump_table"
 require "function"
+require "mutex"
 
 if os.getenv("STRESS") then
     require "channel-stress"

--- a/tests/lua/thread-stress.lua
+++ b/tests/lua/thread-stress.lua
@@ -6,7 +6,7 @@ test.thread_stress.time = function ()
     local function check_time(real_time, use_time, metric)
         local start_time = os.time()
         effil.sleep(use_time, metric)
-        test.almost_equal(os.time(), start_time + real_time, 1)
+        test.almost_equal(os.time(), start_time + real_time, 2)
     end
     check_time(4, 4, nil) -- seconds by default
     check_time(4, 4, 's')


### PR DESCRIPTION
Please take a look at this proposal. It works like that: 
```
local m = effil.mutex()

m:unique_lock(function()
    -- write
end)

m:shared_lock(function()
    -- read
end)

if not m:try_unique_lock(function() 
    -- ok, you can write
end) then
    -- it's busy right now
end

if not m:try_shared_lock(function() 
    -- ok, you can read
end) then
    -- it's busy right now
end

```