### PR TITLE
Rework thread cancellation, using regular exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ local worker = effil.thread(function()
     effil.sleep(999) -- worker will hang for 999 seconds
 end)()
 
-worker:cancel(1) -- returns true, cause blocking operation was interrupted and thread was canceled
+worker:cancel(1) -- returns true, cause blocking operation was interrupted and thread was cancelled
 ```
    </p>
 </details>
@@ -272,7 +272,7 @@ Working with function Effil can store function environment (`_ENV`) as well. Con
 # API Reference
 
 ## Thread
-`effil.thread` is the way to create a thread. Threads can be stopped, paused, resumed and canceled.
+`effil.thread` is the way to create a thread. Threads can be stopped, paused, resumed and cancelled.
 All operation with threads can be synchronous (with optional timeout) or asynchronous.
 Each thread runs with its own lua state.
 
@@ -309,7 +309,7 @@ Thread handle provides API for interaction with thread.
 Returns thread status.
 
 **output**:
-- `status` - string values describes status of thread. Possible values are: `"running", "paused", "canceled", "completed" and "failed"`.
+- `status` - string values describes status of thread. Possible values are: `"running", "paused", "cancelled", "completed" and "failed"`.
 - `err` - error message, if any. This value is specified only if thread status == `"failed"`.
 - `stacktrace` - stacktrace of failed thread. This value is specified only if thread status == `"failed"`.
 

--- a/src/cpp/channel.cpp
+++ b/src/cpp/channel.cpp
@@ -52,7 +52,7 @@ bool Channel::push(const sol::variadic_args& args) {
 
 StoredArray Channel::pop(const sol::optional<int>& duration,
                           const sol::optional<std::string>& period) {
-    this_thread::interruptionPoint();
+    this_thread::cancellationPoint();
     std::unique_lock<std::mutex> lock(ctx_->lock_);
     {
         this_thread::ScopedSetInterruptable interruptable(this);
@@ -70,7 +70,7 @@ StoredArray Channel::pop(const sol::optional<int>& duration,
             else { // No time limit
                 ctx_->cv_.wait(lock);
             }
-            this_thread::interruptionPoint();
+            this_thread::cancellationPoint();
         }
     }
 

--- a/src/cpp/lua-module.cpp
+++ b/src/cpp/lua-module.cpp
@@ -1,8 +1,9 @@
-#include "threading.h"
+#include "thread.h"
+#include "this-thread.h"
+#include "thread-runner.h"
 #include "shared-table.h"
 #include "garbage-collector.h"
 #include "channel.h"
-#include "thread_runner.h"
 
 #include <lua.hpp>
 
@@ -100,6 +101,7 @@ int luaopen_effil(lua_State* L) {
         "thread_id",    this_thread::threadId,
         "sleep",        this_thread::sleep,
         "yield",        this_thread::yield,
+        "pcall",        this_thread::pcall,
         "table",        createTable,
         "rawset",       SharedTable::luaRawSet,
         "rawget",       SharedTable::luaRawGet,
@@ -115,7 +117,6 @@ int luaopen_effil(lua_State* L) {
         "hardware_threads", std::thread::hardware_concurrency,
         sol::meta_function::index, luaIndex
     );
-
     sol::stack::push(lua, type);
     sol::stack::pop<sol::object>(lua);
     sol::stack::push(lua, EffilApiMarker());

--- a/src/cpp/notifier.h
+++ b/src/cpp/notifier.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <this_thread.h>
+#include <this-thread.h>
 #include <lua-helpers.h>
 
 #include <mutex>

--- a/src/cpp/notifier.h
+++ b/src/cpp/notifier.h
@@ -29,20 +29,20 @@ public:
     }
 
     void wait() {
-        this_thread::interruptionPoint();
+        this_thread::cancellationPoint();
 
         this_thread::ScopedSetInterruptable interruptable(this);
 
         std::unique_lock<std::mutex> lock(mutex_);
         while (!notified_) {
             cv_.wait(lock);
-            this_thread::interruptionPoint();
+            this_thread::cancellationPoint();
         }
     }
 
     template <typename T>
     bool waitFor(T period) {
-        this_thread::interruptionPoint();
+        this_thread::cancellationPoint();
 
         if (period == std::chrono::seconds(0) || notified_)
             return notified_;
@@ -54,7 +54,7 @@ public:
         while (!timer.isFinished() &&
                cv_.wait_for(lock, timer.left()) != std::cv_status::timeout &&
                !notified_) {
-            this_thread::interruptionPoint();
+            this_thread::cancellationPoint();
         }
         return notified_;
     }

--- a/src/cpp/stored-object.cpp
+++ b/src/cpp/stored-object.cpp
@@ -1,10 +1,10 @@
 #include "stored-object.h"
 #include "channel.h"
-#include "threading.h"
+#include "thread.h"
 #include "shared-table.h"
 #include "function.h"
 #include "utils.h"
-#include "thread_runner.h"
+#include "thread-runner.h"
 
 #include <map>
 #include <vector>

--- a/src/cpp/this-thread.cpp
+++ b/src/cpp/this-thread.cpp
@@ -1,0 +1,83 @@
+#include "this-thread.h"
+
+#include "thread-handle.h"
+#include "notifier.h"
+
+namespace effil {
+namespace this_thread {
+
+ScopedSetInterruptable::ScopedSetInterruptable(IInterruptable* notifier) {
+    if (const auto thisThread = ThreadHandle::getThis()) {
+        thisThread->setNotifier(notifier);
+    }
+}
+
+ScopedSetInterruptable::~ScopedSetInterruptable() {
+    if (const auto thisThread = ThreadHandle::getThis()) {
+        thisThread->setNotifier(nullptr);
+    }
+}
+
+void interruptionPoint() {
+    const auto thisThread = ThreadHandle::getThis();
+    if (thisThread && thisThread->command() == ThreadHandle::Command::Cancel) {
+        thisThread->changeStatus(ThreadHandle::Status::Cancelled);
+        throw LuaHookStopException();
+    }
+}
+
+std::string threadId() {
+    std::stringstream ss;
+    ss << std::this_thread::get_id();
+    return ss.str();
+}
+
+void yield() {
+    if (const auto thisThread = ThreadHandle::getThis()) {
+        thisThread->performInterruptionPoint();
+    }
+    std::this_thread::yield();
+}
+
+void sleep(const sol::stack_object& duration, const sol::stack_object& metric) {
+    if (duration.valid()) {
+        REQUIRE(duration.get_type() == sol::type::number)
+                << "bad argument #1 to 'effil.sleep' (number expected, got "
+                << luaTypename(duration) << ")";
+
+        if (metric.valid())
+        {
+            REQUIRE(metric.get_type() == sol::type::string)
+                    << "bad argument #2 to 'effil.sleep' (string expected, got "
+                    << luaTypename(metric) << ")";
+        }
+        try {
+            Notifier notifier;
+            notifier.waitFor(fromLuaTime(duration.as<int>(),
+                                         metric.as<sol::optional<std::string>>()));
+        } RETHROW_WITH_PREFIX("effil.sleep");
+    }
+    else {
+        yield();
+    }
+}
+
+int pcall(lua_State* L)
+{
+    int status;
+    luaL_checkany(L, 1);
+    status = lua_pcall(L, lua_gettop(L) - 1, LUA_MULTRET, 0);
+
+    const auto thisThread = ThreadHandle::getThis();
+    if (thisThread && thisThread->command() == ThreadHandle::Command::Cancel) {
+        lua_pushstring(L, LuaHookStopException::message);
+        lua_error(L);
+    }
+
+    lua_pushboolean(L, (status == 0));
+    lua_insert(L, 1);
+    return lua_gettop(L);  /* return status + all results */
+}
+
+} // namespace this_thread
+} // namespace effil

--- a/src/cpp/this-thread.cpp
+++ b/src/cpp/this-thread.cpp
@@ -18,7 +18,7 @@ ScopedSetInterruptable::~ScopedSetInterruptable() {
     }
 }
 
-void interruptionPoint() {
+void cancellationPoint() {
     const auto thisThread = ThreadHandle::getThis();
     if (thisThread && thisThread->command() == ThreadHandle::Command::Cancel) {
         thisThread->changeStatus(ThreadHandle::Status::Cancelled);

--- a/src/cpp/this-thread.cpp
+++ b/src/cpp/this-thread.cpp
@@ -22,7 +22,7 @@ void cancellationPoint() {
     const auto thisThread = ThreadHandle::getThis();
     if (thisThread && thisThread->command() == ThreadHandle::Command::Cancel) {
         thisThread->changeStatus(ThreadHandle::Status::Cancelled);
-        throw LuaHookStopException();
+        throw ThreadCancelException();
     }
 }
 
@@ -70,7 +70,7 @@ int pcall(lua_State* L)
 
     const auto thisThread = ThreadHandle::getThis();
     if (thisThread && thisThread->command() == ThreadHandle::Command::Cancel) {
-        lua_pushstring(L, LuaHookStopException::message);
+        lua_pushstring(L, ThreadCancelException::message);
         lua_error(L);
     }
 

--- a/src/cpp/this-thread.cpp
+++ b/src/cpp/this-thread.cpp
@@ -34,7 +34,7 @@ std::string threadId() {
 
 void yield() {
     if (const auto thisThread = ThreadHandle::getThis()) {
-        thisThread->performInterruptionPoint();
+        thisThread->performInterruptionPointThrow();
     }
     std::this_thread::yield();
 }

--- a/src/cpp/this-thread.h
+++ b/src/cpp/this-thread.h
@@ -14,12 +14,12 @@ public:
     ScopedSetInterruptable(IInterruptable* notifier);
     ~ScopedSetInterruptable();
 };
-void interruptionPoint();
 
-// Lua API
+void interruptionPoint();
 std::string threadId();
 void yield();
 void sleep(const sol::stack_object& duration, const sol::stack_object& metric);
+int pcall(lua_State* L);
 
 } // namespace this_thread
 } // namespace effil

--- a/src/cpp/this-thread.h
+++ b/src/cpp/this-thread.h
@@ -15,7 +15,7 @@ public:
     ~ScopedSetInterruptable();
 };
 
-void interruptionPoint();
+void cancellationPoint();
 std::string threadId();
 void yield();
 void sleep(const sol::stack_object& duration, const sol::stack_object& metric);

--- a/src/cpp/thread-handle.cpp
+++ b/src/cpp/thread-handle.cpp
@@ -1,0 +1,68 @@
+#include "thread-handle.h"
+
+namespace effil {
+
+// Thread specific pointer to current thread
+static thread_local ThreadHandle* thisThreadHandle = nullptr;
+static const sol::optional<std::chrono::milliseconds> NO_TIMEOUT;
+
+ThreadHandle::ThreadHandle()
+        : status_(Status::Running)
+        , command_(Command::Run)
+        , currNotifier_(nullptr)
+        , lua_(std::make_unique<sol::state>())
+{
+    luaL_openlibs(*lua_);
+}
+
+void ThreadHandle::putCommand(Command cmd) {
+    std::unique_lock<std::mutex> lock(stateLock_);
+    if (isFinishStatus(status_) || command() == Command::Cancel)
+        return;
+
+    command_ = cmd;
+    statusNotifier_.reset();
+    commandNotifier_.notify();
+}
+
+void ThreadHandle::changeStatus(Status stat) {
+    std::unique_lock<std::mutex> lock(stateLock_);
+    status_ = stat;
+    commandNotifier_.reset();
+    statusNotifier_.notify();
+    if (isFinishStatus(stat))
+        completionNotifier_.notify();
+}
+
+void ThreadHandle::performInterruptionPoint() {
+    switch (command()) {
+        case Command::Run:
+            break;
+        case Command::Cancel:
+            throw LuaHookStopException();
+        case Command::Pause: {
+            changeStatus(Status::Paused);
+            Command cmd;
+            do {
+                cmd = waitForCommandChange(NO_TIMEOUT);
+            } while(cmd != Command::Run && cmd != Command::Cancel);
+            if (cmd == Command::Run) {
+                changeStatus(Status::Running);
+            } else {
+                throw LuaHookStopException();
+            }
+            break;
+        }
+    }
+}
+
+ThreadHandle* ThreadHandle::getThis() {
+    return thisThreadHandle;
+}
+
+void ThreadHandle::setThis(ThreadHandle* handle) {
+    assert(handle);
+    thisThreadHandle = handle;
+}
+
+} // namespace effil

--- a/src/cpp/thread-handle.cpp
+++ b/src/cpp/thread-handle.cpp
@@ -39,7 +39,7 @@ void ThreadHandle::performInterruptionPoint() {
         case Command::Run:
             break;
         case Command::Cancel:
-            throw LuaHookStopException();
+            throw ThreadCancelException();
         case Command::Pause: {
             changeStatus(Status::Paused);
             Command cmd;
@@ -49,7 +49,7 @@ void ThreadHandle::performInterruptionPoint() {
             if (cmd == Command::Run) {
                 changeStatus(Status::Running);
             } else {
-                throw LuaHookStopException();
+                throw ThreadCancelException();
             }
             break;
         }

--- a/src/cpp/thread-handle.h
+++ b/src/cpp/thread-handle.h
@@ -41,7 +41,8 @@ public:
     Command command() const { return command_; }
     void putCommand(Command cmd);
     void changeStatus(Status stat);
-    void performInterruptionPoint();
+    void performInterruptionPoint(lua_State* L);
+    void performInterruptionPointThrow();
 
     static ThreadHandle* getThis();
 
@@ -109,6 +110,8 @@ private:
     StoredArray result_;
     IInterruptable* currNotifier_;
     std::unique_ptr<sol::state> lua_;
+
+    void performInterruptionPointImpl(const std::function<void(void)>& cancelClbk);
 
     static void setThis(ThreadHandle* handle);
     friend class Thread;

--- a/src/cpp/thread-handle.h
+++ b/src/cpp/thread-handle.h
@@ -8,12 +8,12 @@
 
 namespace effil {
 
-class LuaHookStopException : public std::runtime_error
+class ThreadCancelException : public std::runtime_error
 {
 public:
     static constexpr auto message = "Effil: thread is cancelled";
 
-    LuaHookStopException()
+    ThreadCancelException()
         : std::runtime_error(message)
     {}
 };

--- a/src/cpp/thread-handle.h
+++ b/src/cpp/thread-handle.h
@@ -1,19 +1,31 @@
 #pragma once
 
 #include "lua-helpers.h"
-#include "function.h"
 #include "notifier.h"
+#include "gc-data.h"
 
 #include <sol.hpp>
 
 namespace effil {
+
+class LuaHookStopException : public std::runtime_error
+{
+public:
+    static constexpr auto message = "Effil: thread is cancelled";
+
+    LuaHookStopException()
+        : std::runtime_error(message)
+    {}
+};
+
+class Thread;
 
 class ThreadHandle : public GCData {
 public:
     enum class Status {
         Running,
         Paused,
-        Canceled,
+        Cancelled,
         Completed,
         Failed
     };
@@ -29,6 +41,13 @@ public:
     Command command() const { return command_; }
     void putCommand(Command cmd);
     void changeStatus(Status stat);
+    void performInterruptionPoint();
+
+    static ThreadHandle* getThis();
+
+    static bool isFinishStatus(Status stat) {
+        return stat == Status::Cancelled || stat == Status::Completed || stat == Status::Failed;
+    }
 
     template <typename T>
     Status waitForStatusChange(const sol::optional<T>& time) {
@@ -90,38 +109,9 @@ private:
     StoredArray result_;
     IInterruptable* currNotifier_;
     std::unique_ptr<sol::state> lua_;
+
+    static void setThis(ThreadHandle* handle);
+    friend class Thread;
 };
 
-class Thread : public GCObject<ThreadHandle> {
-public:
-    static void exportAPI(sol::state_view& lua);
-
-    StoredArray status(const sol::this_state& state);
-    StoredArray wait(const sol::this_state& state,
-                     const sol::optional<int>& duration,
-                     const sol::optional<std::string>& period);
-    StoredArray get(const sol::optional<int>& duration,
-                   const sol::optional<std::string>& period);
-    bool cancel(const sol::this_state& state,
-                const sol::optional<int>& duration,
-                const sol::optional<std::string>& period);
-    bool pause(const sol::this_state&,
-               const sol::optional<int>& duration,
-               const sol::optional<std::string>& period);
-    void resume();
-
-private:
-    Thread() = default;
-    void initialize(
-        const std::string& path,
-        const std::string& cpath,
-        int step,
-        const sol::function& function,
-        const sol::variadic_args& args);
-    friend class GC;
-
-private:
-    static void runThread(Thread, Function, effil::StoredArray);
-};
-
-} // effil
+} // namespace effil

--- a/src/cpp/thread-runner.cpp
+++ b/src/cpp/thread-runner.cpp
@@ -1,4 +1,4 @@
-#include "thread_runner.h"
+#include "thread-runner.h"
 
 namespace effil {
 

--- a/src/cpp/thread-runner.h
+++ b/src/cpp/thread-runner.h
@@ -1,4 +1,4 @@
-#include "threading.h"
+#include "thread.h"
 #include "gc-data.h"
 #include "gc-object.h"
 

--- a/src/cpp/thread.cpp
+++ b/src/cpp/thread.cpp
@@ -44,28 +44,7 @@ const lua_CFunction luaErrorHandlerPtr = luaErrorHandler;
 
 void luaHook(lua_State* L, lua_Debug*) {
     if (const auto thisThread = ThreadHandle::getThis()) {
-        switch (thisThread->command()) {
-            case Command::Run:
-                break;
-            case Command::Pause: {
-                thisThread->changeStatus(Status::Paused);
-                Command cmd;
-                do {
-                    cmd = thisThread->waitForCommandChange(sol::optional<std::chrono::milliseconds>());
-                } while(cmd != Command::Run && cmd != Command::Cancel);
-                if (cmd == Command::Run) {
-                    thisThread->changeStatus(Status::Running);
-                } else {
-                    lua_pushstring(L, ThreadCancelException::message);
-                    lua_error(L);
-                }
-                break;
-            }
-            case Command::Cancel:
-                lua_pushstring(L, ThreadCancelException::message);
-                lua_error(L);
-                break;
-        }
+        thisThread->performInterruptionPoint(L);
     }
 }
 

--- a/src/cpp/thread.cpp
+++ b/src/cpp/thread.cpp
@@ -44,12 +44,13 @@ const lua_CFunction luaErrorHandlerPtr = luaErrorHandler;
 
 void luaHook(lua_State* L, lua_Debug*) {
     if (const auto thisThread = ThreadHandle::getThis()) {
-        try {
-            ThreadHandle::getThis()->performInterruptionPoint();
-        } catch(const ThreadCancelException& err) {
-            lua_pushstring(L, err.what());
-            lua_error(L);
-        }
+        ThreadHandle::getThis()->performInterruptionPoint();
+        // try {
+        //     ThreadHandle::getThis()->performInterruptionPoint();
+        // } catch(const ThreadCancelException& err) {
+        //     lua_pushstring(L, err.what());
+        //     lua_error(L);
+        // }
     }
 }
 

--- a/src/cpp/thread.cpp
+++ b/src/cpp/thread.cpp
@@ -96,7 +96,7 @@ void Thread::runThread(
         }
         thread.ctx_->changeStatus(Status::Completed);
     } catch (const std::exception& err) {
-        if (thread.ctx_->command() == Command::Cancel) {
+        if (thread.ctx_->command() == Command::Cancel && strcmp(err.what(), LuaHookStopException::message) == 0) {
             thread.ctx_->changeStatus(Status::Cancelled);
         } else {
             DEBUG("thread") << "Failed with msg: " << err.what() << std::endl;

--- a/src/cpp/thread.cpp
+++ b/src/cpp/thread.cpp
@@ -44,13 +44,28 @@ const lua_CFunction luaErrorHandlerPtr = luaErrorHandler;
 
 void luaHook(lua_State* L, lua_Debug*) {
     if (const auto thisThread = ThreadHandle::getThis()) {
-        ThreadHandle::getThis()->performInterruptionPoint();
-        // try {
-        //     ThreadHandle::getThis()->performInterruptionPoint();
-        // } catch(const ThreadCancelException& err) {
-        //     lua_pushstring(L, err.what());
-        //     lua_error(L);
-        // }
+        switch (thisThread->command()) {
+            case Command::Run:
+                break;
+            case Command::Pause: {
+                thisThread->changeStatus(Status::Paused);
+                Command cmd;
+                do {
+                    cmd = thisThread->waitForCommandChange(sol::optional<std::chrono::milliseconds>());
+                } while(cmd != Command::Run && cmd != Command::Cancel);
+                if (cmd == Command::Run) {
+                    thisThread->changeStatus(Status::Running);
+                } else {
+                    lua_pushstring(L, ThreadCancelException::message);
+                    lua_error(L);
+                }
+                break;
+            }
+            case Command::Cancel:
+                lua_pushstring(L, ThreadCancelException::message);
+                lua_error(L);
+                break;
+        }
     }
 }
 

--- a/src/cpp/thread.h
+++ b/src/cpp/thread.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "lua-helpers.h"
+#include "function.h"
+#include "thread-handle.h"
+
+#include <sol.hpp>
+
+namespace effil {
+
+class Thread : public GCObject<ThreadHandle> {
+public:
+    static void exportAPI(sol::state_view& lua);
+
+    StoredArray status(const sol::this_state& state);
+    StoredArray wait(const sol::this_state& state,
+                     const sol::optional<int>& duration,
+                     const sol::optional<std::string>& period);
+    StoredArray get(const sol::optional<int>& duration,
+                   const sol::optional<std::string>& period);
+    bool cancel(const sol::this_state& state,
+                const sol::optional<int>& duration,
+                const sol::optional<std::string>& period);
+    bool pause(const sol::this_state&,
+               const sol::optional<int>& duration,
+               const sol::optional<std::string>& period);
+    void resume();
+
+private:
+    Thread() = default;
+    void initialize(
+        const std::string& path,
+        const std::string& cpath,
+        int step,
+        const sol::function& function,
+        const sol::variadic_args& args);
+    friend class GC;
+
+private:
+    static void runThread(Thread, Function, effil::StoredArray);
+};
+
+} // effil

--- a/src/cpp/utils.h
+++ b/src/cpp/utils.h
@@ -23,10 +23,10 @@ int luaopen_effil(lua_State* L);
 
 namespace effil {
 
-class Exception : public sol::error {
+class Exception : public std::runtime_error {
 public:
     Exception() noexcept
-            : sol::error("") {}
+        : std::runtime_error("") {}
 
     template <typename T>
     Exception& operator<<(const T& value) {

--- a/tests/lua/thread-interrupt.lua
+++ b/tests/lua/thread-interrupt.lua
@@ -16,7 +16,7 @@ local function interruption_test(worker)
     local start_time = os.time()
     thr:cancel(1)
 
-    test.equal(thr:status(), "canceled")
+    test.equal(thr:status(), "cancelled")
     test.almost_equal(os.time(), start_time, 1)
     state.stop = true
 end

--- a/tests/lua/thread-stress.lua
+++ b/tests/lua/thread-stress.lua
@@ -6,7 +6,7 @@ test.thread_stress.time = function ()
     local function check_time(real_time, use_time, metric)
         local start_time = os.time()
         effil.sleep(use_time, metric)
-        test.almost_equal(os.time(), start_time + real_time, 1)
+        test.almost_equal(os.time(), start_time + real_time, 2)
     end
     check_time(4, 4, nil) -- seconds by default
     check_time(4, 4, 's')

--- a/tests/lua/thread.lua
+++ b/tests/lua/thread.lua
@@ -471,6 +471,24 @@ test.thread.cancel_thread_with_pcall_not_cancelled = function()
     test.equal(thr:wait(), "completed")
 end
 
+test.thread.cancel_thread_with_pcall_and_another_error = function()
+    local msg = 'some text'
+    local thr = effil.thread(
+        function()
+            pcall(function()
+                while true do
+                    effil.yield()
+                end
+            end)
+            error(msg)
+        end
+    )()
+    test.is_true(thr:cancel())
+    local status, message = thr:wait()
+    test.equal(status, "failed")
+    test.is_not_nil(string.find(message, ".+: " .. msg))
+end
+
 if not jit then
 
 test.thread.cancel_thread_with_pcall_without_yield = function()


### PR DESCRIPTION
Previous implementation of thread cancellation may cause `SIGFAULT` in some cases with `pcall` usage.
Now it uses regular lua error and works fine, but cancellation error can be caught using `pcall`. So, this change breaks back compatibility.